### PR TITLE
fix: add proper pre-commit hook id for golangci-lint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @karmingc

--- a/.github/scripts/get-changelog
+++ b/.github/scripts/get-changelog
@@ -34,7 +34,6 @@ fi
 
 # Current workaround for running a forked version of go-change.
 # Can revisit once https://github.com/AaronFriel/go-change/pull/21 is merged.
-go mod init github.com/karmingc/python-template
 go mod edit -replace=github.com/aaronfriel/go-change=github.com/karmingc/go-change@v0.2.2
 go get github.com/aaronfriel/go-change
 go run github.com/aaronfriel/go-change render --filter-since-commit "${MERGE_BASE}" "${@}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.52.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11.2"
-          cache: "pip"
 
       - name: Install pre-commit
         run: python -m pip install pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,5 @@ repos:
       - id: end-of-file-fixer
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.52.2
+    hooks:
+      - id: golangci-lint

--- a/changelog/pending/20230526--fix-ci-cd-developer-experience--add-proper-hook-id-to-golangci-lint.yaml
+++ b/changelog/pending/20230526--fix-ci-cd-developer-experience--add-proper-hook-id-to-golangci-lint.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: patch
+  scope: fix/developer experience,ci/cd
+  description: Add proper hook id to golangci-lint


### PR DESCRIPTION
It was missing the proper hook id.